### PR TITLE
Rewrite how issues are printed

### DIFF
--- a/modules/github.js
+++ b/modules/github.js
@@ -1,22 +1,26 @@
 "use strict";
-const helper = require("./github_helpers");
-var commands = function(bot, options, action) {
-	const message = action.message.split(" ");
-	let query;
-	let target = action.target;
 
-	if (message.length < 1) {
+const helper = require("./github_helpers");
+
+var commands = function(bot, options, action) {
+	if (action.message.length < 2) {
 		return;
 	}
+
+	let query;
+	let target = action.target;
 
 	if (action.target === bot.user.nick) {
 		target = action.nick;
 	}
 
 	if (action.message.startsWith(options.commandPrefix) || action.message.startsWith(options.botName)) {
+		const message = action.message.split(" ");
+
 		if (message[0] === "!github" || message[0] === "!gh") {
 			message.shift(); // remove the command
 			const arg = message[0];
+
 			if (message.length === 1) {
 				if (helper.stringIsPositiveInteger(arg)) {
 					query = helper.getIssueInformation({
@@ -43,6 +47,7 @@ var commands = function(bot, options, action) {
 					query = action.nick + ": invalid command.";
 				}
 			}
+
 			if (query) {
 				// if it's returned as a Promise
 				if (typeof query.then === "function") {
@@ -57,6 +62,7 @@ var commands = function(bot, options, action) {
 			}
 		}
 	}
+
 	if (action.message.indexOf("#") > -1 && options.ignore.indexOf(action.nick) === -1) { // if the message contains # and isn't an ignored user
 		const issues = action.message.match(/#([0-9]*)/g);
 		if (issues) {

--- a/modules/github_helpers.js
+++ b/modules/github_helpers.js
@@ -29,57 +29,44 @@ function stringIsPositiveInteger(string) {
 
 function getIssueInformation(options) {
 	const {repo = config.githubRepo, user = config.githubUser, issue} = options;
-	const issueNumber = issue;
-	if (stringIsPositiveInteger(issueNumber.toString())) {
-		const url = format("https://api.github.com/repos/%s/%s/issues/%s", user, repo, issueNumber);
-		return fetch(url)
-			.then((res) => res.json())
-			.then(function(res) {
-				if (res.message === "Not Found") {
-					return "";
-				}
+	const url = format("https://api.github.com/repos/%s/%s/issues/%s", user, repo, issue);
 
-				let type = res.pull_request === undefined ? "Issue" : "PR";
-				let status = res.state;
-				let title = res.title;
-				let link = res.html_url;
-
-				if (type === "PR" && status === "closed") {
-					return fetch(res.pull_request.url)
-						.then((res2) => res2.json())
-						.then((res3) => {
-							if (res3.message === "Not Found") {
-								return "";
-							}
-
-							type = "PR";
-							status = res3.merged_at === null ? c.red("closed") : c.green("merged");
-							title = res3.title;
-							link = res3.html_url;
-
-							return format("[%s %s] (%s) %s (%s)", c.bold.pink(type), c.bold.pink(issueNumber), status, title, link);
-						});
-				}
-
-				return format("[%s %s] (%s) %s (%s)", c.bold.pink(type), c.bold.pink(issueNumber), status, title, link);
-			});
-	}
-	const url = format("https://api.github.com/repos/%s/%s/commits/%s", user, repo, issueNumber);
 	return fetch(url)
 		.then((res) => res.json())
-		.then(function(res) {
+		.then((res) => {
 			if (res.message === "Not Found") {
+				return {};
+			}
+
+			if (res.pull_request !== undefined && res.state === "closed") {
+				return fetch(res.pull_request.url)
+					.then((res2) => res2.json())
+					.then((res2) => {
+						if (res2.message === "Not Found") {
+							return res;
+						}
+
+						if (res2.merged_at !== null) {
+							res.state = "merged";
+						}
+
+						return res;
+					});
+			}
+
+			return res;
+		})
+		.then((res) => {
+			if (!res.title) {
 				return "";
 			}
 
-			const type = "Commit";
-			const author = res.commit.author.name;
-			const message = res.commit.message;
-			const link = res.html_url;
-			const add = res.stats.additions;
-			const del = res.stats.deletions;
+			const prefix = res.pull_request === undefined ? "issue" : "pull request";
+			const color = res.state === "closed" ? "red" : "green";
 
-			return format("[%s %s] - %s (add: %s, del: %s) - %s", c.bold.pink(type), author, message, add, del, link);
+			res.state = capitalizeFirstLetter(res.state);
+
+			return `🤖 ${c[color](`${res.state} ${prefix}`)} ${c.bold.blue(`#${res.number}`)} - ${res.title} ${res.html_url}`;
 		});
 }
 
@@ -87,6 +74,7 @@ function searchGithub(options) {
 	const {repo = config.githubRepo, user = config.githubUser, terms} = options;
 	let status = null;
 	const url = `https://api.github.com/search/issues?q=repo:${user}/${repo}+${terms.join("+")}`;
+
 	return fetch(url)
 		.then((res) => res.json())
 		.then(function(res) {
@@ -100,17 +88,24 @@ function searchGithub(options) {
 			} else {
 				return "No issue found";
 			}
+
 			const title = res.items[0].title;
 			const link = res.items[0].html_url;
 			const issueNumber = res.items[0].number;
 			let type = "";
+
 			if (link.indexOf("issues") > -1) {
 				type = "Issue";
 			} else {
 				type = "PR";
 			}
+
 			return format("[%s %s] (%s) %s (%s)", c.bold.pink(type), c.bold.pink(issueNumber), status, title, link);
 		});
+}
+
+function capitalizeFirstLetter(string) {
+	return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
 module.exports = {

--- a/modules/github_helpers.js
+++ b/modules/github_helpers.js
@@ -66,7 +66,7 @@ function getIssueInformation(options) {
 
 			res.state = capitalizeFirstLetter(res.state);
 
-			return `🤖 ${c[color](`${res.state} ${prefix}`)} ${c.bold.blue(`#${res.number}`)} - ${res.title} ${res.html_url}`;
+			return `${c.olive("»")} ${c[color](`${res.state} ${prefix}`)} ${c.bold.blue(`#${res.number}`)} - ${res.title} ${res.html_url}`;
 		});
 }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "3.3.1",
-    "es6-shim": "0.34.4",
     "ip": "1.1.5",
     "irc-colors": "1.3.3",
     "irc-framework": "2.8.1",


### PR DESCRIPTION
`getIssueInformation` had code to retrieve commit information, but there was no way to trigger it so I removed it for now. It would be useful to reimplement it though (#aaaaaaa maybe?)