### PR TITLE
Test for `thelounge` nick when greeting, and use monospace formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ bot.on("message", function(event) {
 bot.on("join", function(event) {
 	util.log(event.nick + " joined");
 
-	if (event.nick.indexOf("lounge-user") > -1) {
-		bot.say(event.nick, "Hey " + event.nick + ", now that you've figured out how to use The Lounge, feel free to change your nickname to something more personal using `/nick <new_nickname>` so we know who you are! 🙂");
+	if (event.nick.startsWith("lounge-user") || event.nick.startsWith("thelounge")) {
+		bot.say(event.nick, `👋 Hey \x02${event.nick}\x0F, now that you've figured out how to use The Lounge, feel free to change your nickname to something more personal using \x11/nick <new_nickname>\x0F command so we know who you are! 🙂`);
 	}
 });
 


### PR DESCRIPTION
I'm not totally sure if this actually worked, but nick is supposed to be bold, and IRC command is supposed to be monospaced:

<img width="506" alt="screen shot 2018-02-26 at 01 41 09" src="https://user-images.githubusercontent.com/113730/36656464-93dccd04-1a96-11e8-82d1-8eba5a693d4d.png">

Expected result:

<img width="763" alt="screen shot 2018-02-26 at 01 44 59" src="https://user-images.githubusercontent.com/113730/36656497-b1cfbdda-1a96-11e8-8624-557cf59d9cd9.png">

If it didn't work, I'm not sure how to pass the styling characters.

See [this](https://github.com/thelounge/thelounge/pull/2090/files#diff-52c94142bc27c457f61fa5546d66528b) for new default nick.