### PR TITLE
Change the IRC server to Libera.Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lounge-bot
 
-A node-js IRC bot for [The Lounge's](https://www.github.com/TheLounge) IRC channel on freenode.
+A node-js IRC bot for [The Lounge's](https://www.github.com/TheLounge) IRC channel on Libera.Chat.
 
 ### Setup and running
 
@@ -17,7 +17,7 @@ Configuration information can be found in the config.json. The default options a
 ```js
 var config = {
   channels: ["#thelounge-test"],
-  server: "chat.freenode.net",
+  server: "irc.libera.chat",
   botName: "lounge-botter",
   realName: "TheLounge IRC Bot",
   commandPrefix: "!",

--- a/config.js
+++ b/config.js
@@ -2,7 +2,7 @@
 
 const config = {
 	channels: ["#thelounge-test"],
-	server: "chat.freenode.net",
+	server: "irc.libera.chat",
 	server_port: 6697,
 	server_tls: true,
 	botName: "lounge-botter",


### PR DESCRIPTION
I changed all references from Freenode to Libera.Chat due to the main channel being moved to the Libera.Chat network.